### PR TITLE
Fix typo in footer layout, render name in copyright

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <footer class="footer text-center">
-<p>Copyright &copy; {{ .Now.Format "2006" }} {{ .Site.Params.SelfName }} -
+<p>Copyright &copy; {{ .Now.Format "2006" }} {{ .Site.Params.Name }} -
 <span class="credit">
 	Powered by 
 	<a target="_blank" href="https://gohugo.io">Hugo</a>


### PR DESCRIPTION
Hello. Thanks for the great work on this theme. I'm suggesting (very) minor correction here.

In the example site configuration.toml file, we are recommending the website author's name to be added under .Site.Params.Name . However, in the layouts/partials/footer.html, we have .Site.Params.SelfName . Due to this typo, the copyright doesn't render name correctly in the footer. The change proposed here fixes this issue.