### PR TITLE
workaround for summaries defined with <!--more-->

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -23,7 +23,7 @@
 							<h4 class="post-link"><a href="{{ .Permalink }}">{{ .Title }}</a></h4>
 							<h4 class="post-date">{{ .Date.Format "Jan 2, 2006" }}</h4>
 						</div>
-						<div class="post-summary"><p>{{ .Summary }}...</p></div>
+						<div class="post-summary"><p>{{ .Summary }}</p></div>
 						<div class="post-list-footer text-center">
 							<a href="{{ .Permalink }}">Read More</a>
 						</div>


### PR DESCRIPTION
This is a "workaround" for issue spf13/hugo#1217 where summaries defined with <!--more--> tag have extra <p> tags around them. In the original list.html there were three dots which got pushed to the next line and it didn't look good so I've removed them.