### PR TITLE
Fix Instagram base URL

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -49,7 +49,7 @@
 					<a href="http://linkedin.com/in/{{.}}" title="LinkedIn"><i class="fa fa-linkedin fa-3x" aria-hidden="true"></i></a>
 					{{ end }}
           {{ with .Site.Params.InstagramID }}
-					<a href="https:/instagram.com/{{.}}" title="Instagram"><i class="fa fa-instagram fa-3x" aria-hidden="true"></i></a>
+					<a href="https://instagram.com/{{.}}" title="Instagram"><i class="fa fa-instagram fa-3x" aria-hidden="true"></i></a>
 					{{ end }}
 					{{ with .Site.Params.TelegramID }}
 					<a href="https://t.me/{{.}}" title="Telegram"><i class="fa fa-telegram fa-3x" aria-hidden="true"></i></a>


### PR DESCRIPTION
The generated URL for Instagram was http:/example.com (missing forward slash).