### PR TITLE
Made the social section a partial

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -23,41 +23,7 @@
 			</div>
 			<div class="row">
 				<div class="col-xs-12 user-social text-center">
-
-					{{ with .Site.Params.SlackURL }}
-					<a href="{{.}}" title="Slack"><i class="fa fa-slack fa-3x" aria-hidden="true"></i></a>
-					{{ end }}
-					{{ with .Site.Params.TwitterID }}
-					<a href="https://twitter.com/{{.}}" title="Twitter"><i class="fa fa-twitter fa-3x" aria-hidden="true"></i></a>
-					{{ end }}
-					{{ with .Site.Params.GoogleplusID }}
-					<a href="https://plus.google.com/{{.}}/about" title="Google+"><i class="fa fa-google-plus fa-3x" aria-hidden="true"></i></a>
-					{{ end }}
-					{{ with .Site.Params.FacebookID }}
-					<a href="https://facebook.com/{{.}}" title="Facebook"><i class="fa fa-facebook fa-3x" aria-hidden="true"></i></a>
-					{{ end }}
-					{{ with .Site.Params.GithubID }}
-					<a href="https://github.com/{{.}}" title="GitHub"><i class="fa fa-github fa-3x" aria-hidden="true"></i></a>
-					{{ end }}
-					{{ with .Site.Params.GitlabId }}
-					<a href="https://gitlab.com/{{.}}" title="GitLab"><i class="fa fa-gitlab fa-3x" aria-hidden="true"></i></a>
-					{{ end }}
-          {{ with .Site.Params.CodepenID }}
-					<a href="https://codepen.io/{{.}}" title="Codepen"><i class="fa fa-codepen fa-3x" aria-hidden="true"></i></a>
-          {{ end }}
-					{{ with .Site.Params.LinkedInID }}
-					<a href="http://linkedin.com/in/{{.}}" title="LinkedIn"><i class="fa fa-linkedin fa-3x" aria-hidden="true"></i></a>
-					{{ end }}
-          {{ with .Site.Params.InstagramID }}
-					<a href="https://instagram.com/{{.}}" title="Instagram"><i class="fa fa-instagram fa-3x" aria-hidden="true"></i></a>
-					{{ end }}
-					{{ with .Site.Params.TelegramID }}
-					<a href="https://t.me/{{.}}" title="Telegram"><i class="fa fa-telegram fa-3x" aria-hidden="true"></i></a>
-					{{ end }}
-					{{ with .Site.Params.Email }}
-					<a href="mailto:{{.}}" title="Email"><i class="fa fa-envelope fa-3x" aria-hidden="true"></i></a>
-					{{ end }}
-
+				{{ partial "social.html" . }}
 				</div>
 			</div>
 			<div class="row">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,9 +11,9 @@
 		<div class="container wrapper">
 			{{ with .Site.Params.ProfilePicture }}
 			<div class="row">
-			    <div class="col-sm-3 col-centered">
-			        <img alt="profile-picture" class="img-responsive img-circle user-picture" src="{{.}}">
-			    </div>
+				<div class="col-sm-3 col-centered">
+					<img alt="profile-picture" class="img-responsive img-circle user-picture" src="{{.}}">
+				</div>
 			</div>
 			{{ end }}
 			<div class="row">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,9 +1,9 @@
 <footer class="footer text-center">
 <p>Copyright &copy; {{ now.Format "2006" }} {{ .Site.Params.Name }} -
 <span class="credit">
-	Powered by 
+	Powered by
 	<a target="_blank" href="https://gohugo.io">Hugo</a>
-	and 
+	and
 	<a target="_blank" href="https://github.com/LordMathis/hugo-theme-nix/">Nix</a> theme.
 </span>
 </p>

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -1,0 +1,33 @@
+{{ with .Site.Params.SlackURL }}
+<a href="{{.}}" title="Slack"><i class="fa fa-slack fa-3x" aria-hidden="true"></i></a>
+{{ end }}
+{{ with .Site.Params.TwitterID }}
+<a href="https://twitter.com/{{.}}" title="Twitter"><i class="fa fa-twitter fa-3x" aria-hidden="true"></i></a>
+{{ end }}
+{{ with .Site.Params.GoogleplusID }}
+<a href="https://plus.google.com/{{.}}/about" title="Google+"><i class="fa fa-google-plus fa-3x" aria-hidden="true"></i></a>
+{{ end }}
+{{ with .Site.Params.FacebookID }}
+<a href="https://facebook.com/{{.}}" title="Facebook"><i class="fa fa-facebook fa-3x" aria-hidden="true"></i></a>
+{{ end }}
+{{ with .Site.Params.GithubID }}
+<a href="https://github.com/{{.}}" title="GitHub"><i class="fa fa-github fa-3x" aria-hidden="true"></i></a>
+{{ end }}
+{{ with .Site.Params.GitlabId }}
+<a href="https://gitlab.com/{{.}}" title="GitLab"><i class="fa fa-gitlab fa-3x" aria-hidden="true"></i></a>
+{{ end }}
+{{ with .Site.Params.CodepenID }}
+<a href="https://codepen.io/{{.}}" title="Codepen"><i class="fa fa-codepen fa-3x" aria-hidden="true"></i></a>
+{{ end }}
+{{ with .Site.Params.LinkedInID }}
+<a href="http://linkedin.com/in/{{.}}" title="LinkedIn"><i class="fa fa-linkedin fa-3x" aria-hidden="true"></i></a>
+{{ end }}
+{{ with .Site.Params.InstagramID }}
+<a href="https://instagram.com/{{.}}" title="Instagram"><i class="fa fa-instagram fa-3x" aria-hidden="true"></i></a>
+{{ end }}
+{{ with .Site.Params.TelegramID }}
+<a href="https://t.me/{{.}}" title="Telegram"><i class="fa fa-telegram fa-3x" aria-hidden="true"></i></a>
+{{ end }}
+{{ with .Site.Params.Email }}
+<a href="mailto:{{.}}" title="Email"><i class="fa fa-envelope fa-3x" aria-hidden="true"></i></a>
+{{ end }}

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -20,7 +20,7 @@
 <a href="https://codepen.io/{{.}}" title="Codepen"><i class="fa fa-codepen fa-3x" aria-hidden="true"></i></a>
 {{ end }}
 {{ with .Site.Params.LinkedInID }}
-<a href="http://linkedin.com/in/{{.}}" title="LinkedIn"><i class="fa fa-linkedin fa-3x" aria-hidden="true"></i></a>
+<a href="https://linkedin.com/in/{{.}}" title="LinkedIn"><i class="fa fa-linkedin fa-3x" aria-hidden="true"></i></a>
 {{ end }}
 {{ with .Site.Params.InstagramID }}
 <a href="https://instagram.com/{{.}}" title="Instagram"><i class="fa fa-instagram fa-3x" aria-hidden="true"></i></a>


### PR DESCRIPTION
I was using some weird CSS to overwrite the content of the Font Awesome classes to use square icons instead, and thought it would be much nicer to just write my own list of icons and links. I also want to add RSS (which I've enabled in my custom header partial, and so wouldn't fit upstream without both pieces), so again, a partial makes it much easier. Finally, all links should be HTTPS (like LinkedIn) and I saw some whitespace to clean up. Sorry for mixing the PR, but the changes I think are all reasonable.