### PR TITLE
Use CSS to uppercase name

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,7 +18,7 @@
 			{{ end }}
 			<div class="row">
 				<div class="col-xs-12 user-profile text-center">
-					<h1 id="user-name">{{ upper .Site.Params.Name }}</h1>
+					<h1 id="user-name">{{ .Site.Params.Name }}</h1>
 				</div>
 			</div>
 			<div class="row">

--- a/static/css/nix.css
+++ b/static/css/nix.css
@@ -37,6 +37,7 @@ h1,h2,h3,h4,h5,h6 {
 
 #user-name {
 	font-size: 5em;
+	text-transform: uppercase;
 }
 
 .user-description {


### PR DESCRIPTION
Previously this used the `upper` template directive, which injected UPPERCASE text into the HTML. Unfortunately, the `text-transform` CSS property cannot lowercase or Capitalize UPPERCASE text. However, `text-transform` can UPPERCASE text that is lowercased or Capitalized, so by switching from `upper` to `text-transform` on `#user-name` in `nix.css`, we can allow users to customize how their name is displayed.

Note: This is not a breaking change.