### PR TITLE
Add support for telephone numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Add these parameters to your `config.toml`:
   HeaderUsername = "username"
   HeaderHostname = "hostname"
   Email = "your_email"
+  Phone = "+1-201-555-0123"
+  Mobile = "+1-201-555-0123"
   About = "info_about_you"
   ProfilePicture = "profile_picture_url"
   GoogleAnalytics = "your_google_analytics_id"

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -43,9 +43,16 @@
 {{ with .Site.Params.Email }}
 <a href="mailto:{{.}}" title="Email"><i class="fa fa-envelope fa-3x" aria-hidden="true"></i></a>
 {{ end }}
+{{ with .Site.Params.Phone }}
+<a href="tel:{{.}}" title="Phone"><i class="fa fa-phone fa-3x" aria-hidden="true"></i></a>
+{{ end }}
+{{ with .Site.Params.Mobile }}
+<a href="tel:{{.}}" title="Mobile"><i class="fa fa-mobile fa-3x" aria-hidden="true"></i></a>
+{{ end }}
 {{ with .Site.Params.PayPalMeID }}
 <a href="https://www.paypal.me/{{.}}" title="PayPal.Me"><i class="fa fa-paypal fa-3x" aria-hidden="true"></i></a>
 {{ end }}
 {{ with .Site.Params.XingURL }}
 <a href="{{.}}" title="XING"><i class="fa fa-xing fa-3x" aria-hidden="true"></i></a>
 {{ end }}
+


### PR DESCRIPTION
This feature adds support for [phone](http://fontawesome.io/icon/phone/) and [mobile](http://fontawesome.io/icon/mobile/) numbers. The generated URIs conform to [RFC 3966](https://tools.ietf.org/html/rfc3966) (e.g. "tel:+1-201-555-0123"). You can see the result on my [homepage](https://www.prechtel.eu/).