### PR TITLE
Fix image max-width property

### DIFF
--- a/static/css/nix.css
+++ b/static/css/nix.css
@@ -14,6 +14,11 @@ body {
 	padding-top: 70px;
 }
 
+img {
+ 	max-width: 100%;
+}
+
+
 #green-terminal {
 	color: #00ff00;
 }


### PR DESCRIPTION
This PR fixes #34 by adding a `max-width` property in the CSS to all `img` tags.