### PR TITLE
Add dropdown/submenu functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To add a menu item add `[[menu.header]]` item to `config.toml`. For example:
     url = "/posts"
 ```
 
-To add a submenu item add `[[menu.header]]` item to with a parent parameter in `config.toml`. For example:
+To add a submenu item add `[[menu.header]]` item with a parent parameter to `config.toml`. For example:
 
 ```
 [menu]

--- a/README.md
+++ b/README.md
@@ -60,6 +60,29 @@ To add a menu item add `[[menu.header]]` item to `config.toml`. For example:
     url = "/posts"
 ```
 
+To add a submenu item add `[[menu.header]]` item to with a parent parameter in `config.toml`. For example:
+
+```
+[menu]
+  [[menu.header]]
+    identifier = "post"
+    name = "posts"
+    weight = 0
+    url = "/post"
+  [[menu.header]]
+    parent = "post"
+    name = "All Posts"
+    url = "/post"
+  [[menu.header]]
+    parent = "post"
+    name = "categories"
+    url = "/categories"
+  [[menu.header]]
+    parent = "post"
+    name = "tags"
+    url = "/tags"
+```
+
 To enable disqus comments add `disqusShortname` to your `config.toml`.
 
 You can turn off disqus comments per page by adding `nocomments = true` to the front matter.

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -19,10 +19,21 @@
 				</li>
 				{{ range .Site.Menus.header }}
 				{{ $name := lower .Name }}
-				<li >
-					<a href="{{ .URL }}">~/{{ lower .Name }}</a>
-				</li>
-				{{end}}
+				<li class="dropdown">
+                    {{ if .HasChildren }}
+                        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{{ .Name }} <span class="caret"></span></a>
+                    <ul class="dropdown-menu">
+                        {{ range .Children }}
+                    		<li>
+                    		<a href="{{ .URL }}">~/{{ lower .Name }}</a>
+				    		</li>
+                		{{ end }}
+            		</ul>
+            		{{ else }}
+            		<a href="{{ .URL }}">~/{{ lower .Name }}</a>
+            		{{ end  }}
+        		</li>
+        		{{ end }}
 
 			</ul>
 		</div><!-- /.navbar-collapse -->

--- a/static/css/nix.css
+++ b/static/css/nix.css
@@ -35,6 +35,9 @@ nav {
 	font-size: 1.5em;
 }
 
+.dropdown-menu li {
+	font-size: 1.5em;
+}
 
 h1,h2,h3,h4,h5,h6 {
 	font-family: 'Concert One', cursive;


### PR DESCRIPTION
This PR adds the ability to create a submenu/dropdown in the navigation using the menu section of the `config.toml` with the `identifier` and `parent` parameters. The `.HasChildren` variable has been used in `header.html` to identify the submenu items belonging to a parent item.

This feature has been tested and is currently being used on my site: [chrisfrome.com](https://chrisfrome.com)

