### PR TITLE
Fixes Mastodon URL listing

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -14,7 +14,7 @@
 <a href="https://twitter.com/{{.}}" title="Twitter"><i class="fab fa-twitter fa-3x" aria-hidden="true"></i></a>
 {{ end }}
 {{ with .Site.Params.MastodonURL }}
-<a href="https://twitter.com/{{.}}" title="Mastodon"><i class="fab fa-mastodon fa-3x" aria-hidden="true"></i></a>
+<a href="{{.}}" title="Mastodon"><i class="fab fa-mastodon fa-3x" aria-hidden="true"></i></a>
 {{ end }}
 {{ with .Site.Params.GoogleplusID }}
 <a href="https://plus.google.com/{{.}}/about" title="Google+"><i class="fab fa-google-plus fa-3x" aria-hidden="true"></i></a>


### PR DESCRIPTION
Currently, any use of the `MastodonURL` will end up creating a link to Twitter.