### PR TITLE
fix cv icon

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -62,6 +62,6 @@
 <a href="{{.}}" rel="me" title="XING"><i class="fab fa-xing fa-3x" aria-hidden="true"></i></a>
 {{ end }}
 {{ with .Site.Params.CvURL }}
-<a href="{{.}}" title="Curriculum Vitae"><i class="fas fa-file-text fa-3x" aria-hidden="true"></i></a>
+<a href="{{.}}" title="Curriculum Vitae"><i class="fas fa-file-alt fa-3x" aria-hidden="true"></i></a>
 {{ end }}
 


### PR DESCRIPTION
I'm using your theme and CvURL seems to not appear.
I found it was because `fa-file-text` doesn't exist (they probably change the name recently), so I've change it to `fa-file-alt`.