### PR TITLE
Fix deprecation warning

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,6 @@
 <meta http-equiv="content-type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
-{{ .Hugo.Generator }}
+{{ hugo.Generator }}
 
 <!-- JQuery -->
 <script src="https://code.jquery.com/jquery-3.1.1.min.js"   integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8="   crossorigin="anonymous"></script>


### PR DESCRIPTION
I'm getting these logs constantly:

```
WARN 2019/04/19 Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.
```