### PR TITLE
Add multilingual support

### DIFF
--- a/exampleSite/content/post/creating-a-new-theme.md
+++ b/exampleSite/content/post/creating-a-new-theme.md
@@ -150,13 +150,13 @@ INFO: 2014/09/29 Using config file: config.toml
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 WARN: 2014/09/29 Unable to locate layout: [index.html _default/list.html _default/single.html]
 WARN: 2014/09/29 Unable to locate layout: [404.html]
-0 draft content 
-0 future content 
-0 pages created 
+0 draft content
+0 future content
+0 pages created
 0 tags created
 0 categories created
 in 2 ms
-$ 
+$
 ```
 
 The "`--verbose`" flag gives extra information that will be helpful when we build the template. Every line of the output that starts with "INFO:" or "WARN:" is present because we used that flag. The lines that start with "WARN:" are warning messages. We'll go over them later.
@@ -182,7 +182,7 @@ $ ls -l public
 total 16
 -rw-r--r--  1 quoha  staff  416 Sep 29 17:02 index.xml
 -rw-r--r--  1 quoha  staff  262 Sep 29 17:02 sitemap.xml
-$ 
+$
 ```
 
 Hugo created two XML files, which is standard, but there are no HTML files.
@@ -199,9 +199,9 @@ INFO: 2014/09/29 Using config file: /Users/quoha/Sites/zafta/config.toml
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 WARN: 2014/09/29 Unable to locate layout: [index.html _default/list.html _default/single.html]
 WARN: 2014/09/29 Unable to locate layout: [404.html]
-0 draft content 
-0 future content 
-0 pages created 
+0 draft content
+0 future content
+0 pages created
 0 tags created
 0 categories created
 in 2 ms
@@ -269,7 +269,7 @@ $ find themes -type f | xargs ls -l
 -rw-r--r--  1 quoha  staff     0 Sep 29 17:31 themes/zafta/layouts/partials/footer.html
 -rw-r--r--  1 quoha  staff     0 Sep 29 17:31 themes/zafta/layouts/partials/header.html
 -rw-r--r--  1 quoha  staff    93 Sep 29 17:31 themes/zafta/theme.toml
-$ 
+$
 ```
 
 The skeleton includes templates (the files ending in .html), license file, a description of your theme (the theme.toml file), and an empty archetype.
@@ -332,9 +332,9 @@ INFO: 2014/09/29 Using config file: /Users/quoha/Sites/zafta/config.toml
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-0 pages created 
+0 draft content
+0 future content
+0 pages created
 0 tags created
 0 categories created
 in 2 ms
@@ -379,7 +379,7 @@ When Hugo created our theme, it created an empty home page template. Now, when w
 $ find . -name index.html | xargs ls -l
 -rw-r--r--  1 quoha  staff  0 Sep 29 20:21 ./public/index.html
 -rw-r--r--  1 quoha  staff  0 Sep 29 17:31 ./themes/zafta/layouts/index.html
-$ 
+$
 ```
 
 #### The Magic of Static
@@ -398,7 +398,7 @@ drwxr-xr-x  4 quoha  staff  136 Sep 29 17:31 themes/zafta/layouts/partials
 drwxr-xr-x  4 quoha  staff  136 Sep 29 17:31 themes/zafta/static
 drwxr-xr-x  2 quoha  staff   68 Sep 29 17:31 themes/zafta/static/css
 drwxr-xr-x  2 quoha  staff   68 Sep 29 17:31 themes/zafta/static/js
-$ 
+$
 ```
 
 ## The Theme Development Cycle
@@ -454,9 +454,9 @@ INFO: 2014/09/29 Using config file: /Users/quoha/Sites/zafta/config.toml
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-0 pages created 
+0 draft content
+0 future content
+0 pages created
 0 tags created
 0 categories created
 in 2 ms
@@ -468,9 +468,9 @@ INFO: 2014/09/29 File System Event: ["/Users/quoha/Sites/zafta/themes/zafta/layo
 Change detected, rebuilding site
 
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-0 pages created 
+0 draft content
+0 future content
+0 pages created
 0 tags created
 0 categories created
 in 1 ms
@@ -492,12 +492,12 @@ Right now, that page is empty because we don't have any content and we don't hav
 
 ```
 $ vi themes/zafta/layouts/index.html
-<!DOCTYPE html> 
-<html> 
-<body> 
-  <p>hugo says hello!</p> 
-</body> 
-</html> 
+<!DOCTYPE html>
+<html>
+<body>
+  <p>hugo says hello!</p>
+</body>
+</html>
 :wq
 
 $
@@ -511,9 +511,9 @@ INFO: 2014/09/29 Using config file: /Users/quoha/Sites/zafta/config.toml
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-0 pages created 
+0 draft content
+0 future content
+0 pages created
 0 tags created
 0 categories created
 in 2 ms
@@ -521,11 +521,11 @@ in 2 ms
 $ find public -type f -name '*.html' | xargs ls -l
 -rw-r--r--  1 quoha  staff  78 Sep 29 21:26 public/index.html
 
-$ cat public/index.html 
-<!DOCTYPE html> 
-<html> 
-<body> 
-  <p>hugo says hello!</p> 
+$ cat public/index.html
+<!DOCTYPE html>
+<html>
+<body>
+  <p>hugo says hello!</p>
 </html>
 ```
 
@@ -534,15 +534,15 @@ $ cat public/index.html
 Note: If you're running the server with the `--watch` option, you'll see different content in the file:
 
 ```
-$ cat public/index.html 
-<!DOCTYPE html> 
-<html> 
-<body> 
-  <p>hugo says hello!</p> 
-<script>document.write('<script src="http://' 
-        + (location.host || 'localhost').split(':')[0] 
-    + ':1313/livereload.js?mindelay=10"></' 
-        + 'script>')</script></body> 
+$ cat public/index.html
+<!DOCTYPE html>
+<html>
+<body>
+  <p>hugo says hello!</p>
+<script>document.write('<script src="http://'
+        + (location.host || 'localhost').split(':')[0]
+    + ':1313/livereload.js?mindelay=10"></'
+        + 'script>')</script></body>
 </html>
 ```
 
@@ -565,7 +565,7 @@ INFO: 2014/09/29 attempting to create  post/first.md of post
 INFO: 2014/09/29 curpath: /Users/quoha/Sites/zafta/themes/zafta/archetypes/default.md
 ERROR: 2014/09/29 Unable to Cast <nil> to map[string]interface{}
 
-$ 
+$
 ```
 
 That wasn't very nice, was it?
@@ -604,7 +604,7 @@ total 16
 -rw-r--r--  1 quoha  staff  104 Sep 29 21:54 first.md
 -rw-r--r--  1 quoha  staff  105 Sep 29 21:57 second.md
 
-$ cat content/post/first.md 
+$ cat content/post/first.md
 +++
 Categories = []
 Description = ""
@@ -615,7 +615,7 @@ title = "first"
 +++
 my first post
 
-$ cat content/post/second.md 
+$ cat content/post/second.md
 +++
 Categories = []
 Description = ""
@@ -626,7 +626,7 @@ title = "second"
 +++
 my second post
 
-$ 
+$
 ```
 
 Build the web site and then verify the results.
@@ -639,9 +639,9 @@ INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 found taxonomies: map[string]string{"category":"categories", "tag":"tags"}
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-2 pages created 
+0 draft content
+0 future content
+2 pages created
 0 tags created
 0 categories created
 in 4 ms
@@ -674,7 +674,7 @@ There are three other types of templates: partials, content views, and terms. We
 The home page will contain a list of posts. Let's update its template to add the posts that we just created. The logic in the template will run every time we build the site.
 
 ```
-$ vi themes/zafta/layouts/index.html 
+$ vi themes/zafta/layouts/index.html
 <!DOCTYPE html>
 <html>
 <body>
@@ -712,26 +712,26 @@ INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 found taxonomies: map[string]string{"tag":"tags", "category":"categories"}
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-2 pages created 
+0 draft content
+0 future content
+2 pages created
 0 tags created
 0 categories created
 in 4 ms
-$ find public -type f -name '*.html' | xargs ls -l 
+$ find public -type f -name '*.html' | xargs ls -l
 -rw-r--r--  1 quoha  staff  94 Sep 29 22:23 public/index.html
 -rw-r--r--  1 quoha  staff   0 Sep 29 22:23 public/post/first/index.html
 -rw-r--r--  1 quoha  staff   0 Sep 29 22:23 public/post/index.html
 -rw-r--r--  1 quoha  staff   0 Sep 29 22:23 public/post/second/index.html
-$ cat public/index.html 
+$ cat public/index.html
 <!DOCTYPE html>
 <html>
 <body>
-  
+
     <h1>second</h1>
-  
+
     <h1>first</h1>
-  
+
 </body>
 </html>
 $
@@ -763,7 +763,7 @@ Please see the Hugo documentation on template rendering for all the details on d
 #### Update the Template File
 
 ```
-$ vi themes/zafta/layouts/_default/single.html 
+$ vi themes/zafta/layouts/_default/single.html
 <!DOCTYPE html>
 <html>
 <head>
@@ -789,9 +789,9 @@ INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 found taxonomies: map[string]string{"tag":"tags", "category":"categories"}
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-2 pages created 
+0 draft content
+0 future content
+2 pages created
 0 tags created
 0 categories created
 in 4 ms
@@ -802,7 +802,7 @@ $ find public -type f -name '*.html' | xargs ls -l
 -rw-r--r--  1 quoha  staff    0 Sep 29 22:40 public/post/index.html
 -rw-r--r--  1 quoha  staff  128 Sep 29 22:40 public/post/second/index.html
 
-$ cat public/post/first/index.html 
+$ cat public/post/first/index.html
 <!DOCTYPE html>
 <html>
 <head>
@@ -815,7 +815,7 @@ $ cat public/post/first/index.html
 </body>
 </html>
 
-$ cat public/post/second/index.html 
+$ cat public/post/second/index.html
 <!DOCTYPE html>
 <html>
 <head>
@@ -858,9 +858,9 @@ INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 found taxonomies: map[string]string{"tag":"tags", "category":"categories"}
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-2 pages created 
+0 draft content
+0 future content
+2 pages created
 0 tags created
 0 categories created
 in 4 ms
@@ -871,15 +871,15 @@ $ find public -type f -name '*.html' | xargs ls -l
 -rw-r--r--  1 quoha  staff    0 Sep 29 22:44 public/post/index.html
 -rw-r--r--  1 quoha  staff  128 Sep 29 22:44 public/post/second/index.html
 
-$ cat public/index.html 
+$ cat public/index.html
 <!DOCTYPE html>
 <html>
 <body>
-  
+
     <h1><a href="/post/second/">second</a></h1>
-  
+
     <h1><a href="/post/first/">first</a></h1>
-  
+
 </body>
 </html>
 
@@ -906,7 +906,7 @@ Let's add an "about" page and display it at the top level (as opposed to a sub-l
 The default in Hugo is to use the directory structure of the content/ directory to guide the location of the generated html in the public/ directory. Let's verify that by creating an "about" page at the top level:
 
 ```
-$ vi content/about.md 
+$ vi content/about.md
 +++
 title = "about"
 description = "about this site"
@@ -1089,7 +1089,7 @@ It's common to have posts display the date that they were written or published, 
 We'll start by updating the template used to render the posts. The template code will look like:
 
 ```
-{{ .Date.Format "Mon, Jan 2, 2006" }}
+{{ .Date.Format "Mon, 2006-01-02" }}
 ```
 
 Posts use the default single template, so we'll change that file.
@@ -1099,7 +1099,7 @@ $ vi themes/zafta/layouts/_default/single.html
 {{ partial "header.html" . }}
 
   <h1>{{ .Title }}</h1>
-  <h2>{{ .Date.Format "Mon, Jan 2, 2006" }}</h2>
+  <h2>{{ .Date.Format "Mon, 2006-01-02" }}</h2>
   {{ .Content }}
 
 {{ partial "footer.html" . }}
@@ -1135,7 +1135,7 @@ $ vi themes/zafta/layouts/post/single.html
 {{ partial "header.html" . }}
 
   <h1>{{ .Title }}</h1>
-  <h2>{{ .Date.Format "Mon, Jan 2, 2006" }}</h2>
+  <h2>{{ .Date.Format "Mon, 2006-01-02" }}</h2>
   {{ .Content }}
 
 {{ partial "footer.html" . }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Language.Lang }}">
 
 	<head>
 		<title> {{ .Title }} &middot; {{ .Site.Title }} </title>
@@ -21,7 +21,7 @@
 					<div class="post-list-item">
 						<div class="post-header">
 							<h4 class="post-link"><a href="{{ .Permalink }}">{{ .Title }}</a></h4>
-							<h4 class="post-date">{{ .Date.Format "Jan 2, 2006" }}</h4>
+							<h4 class="post-date">{{ .Date.Format "2006-01-02" }}</h4>
 						</div>
 						<div class="post-summary"><p>{{ .Summary }}</p></div>
 						<div class="post-list-footer text-center">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -11,7 +11,7 @@
         {{ partial "header.html" . }}
         <div class="container wrapper">
             <h1><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
-            <span class="post-date">{{ .Date.Format "Jan 2, 2006 " }}</span>
+            <span class="post-date">{{ .Date.Format "2006-01-02 " }}</span>
             <div class="post-content">
                 {{ .Content }}
             </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,6 +2,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 {{ hugo.Generator }}
 
+{{ if .IsTranslated }}
+  {{ range .Translations }}
+    <link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}" title="{{ .Language.LanguageName }}">
+  {{ end }}
+{{ end }}
+
 <!-- JQuery -->
 <script src="https://code.jquery.com/jquery-3.1.1.min.js"   integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8="   crossorigin="anonymous"></script>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,15 +8,34 @@
 				<span class="icon-bar"></span>
 				<span class="icon-bar"></span>
 			</button>
-			<a class="navbar-brand" id="green-terminal" href={{.Site.BaseURL}}>{{.Site.Params.HeaderUsername}}@{{.Site.Params.HeaderHostname}} ~ $</a>
+      <a class="navbar-brand" id="green-terminal" href='{{ "/" | absLangURL }}'>
+        {{ .Site.Params.HeaderUsername }}@{{ .Site.Params.HeaderHostname }} ~ $
+      </a>
 		</div>
 
 		<!-- Collect the nav links, forms, and other content for toggling -->
 		<div class="collapse navbar-collapse" id="navbar-collapse-1">
 			<ul class="nav navbar-nav navbar-right">
 				<li>
-					<a href="{{ .Site.BaseURL }}">/home/{{.Site.Params.HeaderUsername}}</a>
-				</li>
+					<a href='{{ "/" | absLangURL }}'>/home/{{ .Site.Params.HeaderUsername }}</a>
+        </li>
+        {{ if .IsTranslated }}
+          <li class="dropdown">
+            <a class="dropdown-toggle" data-toggle="dropdown" role="button" title="{{ .Language.LanguageName }}">
+              LANG={{ .Language.Lang }}
+              <span class="caret"></span>
+            </a>
+            <ul class="dropdown-menu">
+              {{ range .Translations }}
+                <li>
+                  <a href="{{ .Permalink }}" title="{{ .Language.LanguageName }}">
+                    export LANG={{ .Language.Lang }}
+                  </a>
+                </li>
+              {{ end }}
+            </ul>
+          </li>
+        {{ end }}
 				{{ range .Site.Menus.header }}
 				{{ $name := lower .Name }}
 				<li class="dropdown">
@@ -25,12 +44,12 @@
                     <ul class="dropdown-menu">
                         {{ range .Children }}
                     		<li>
-                    		<a href="{{ .URL }}">~/{{ lower .Name }}</a>
+                    		<a href="{{ .URL | absLangURL }}">~/{{ lower .Name }}</a>
 				    		</li>
                 		{{ end }}
             		</ul>
             		{{ else }}
-            		<a href="{{ .URL }}">~/{{ lower .Name }}</a>
+            		<a href="{{ .URL | absLangURL }}">~/{{ lower .Name }}</a>
             		{{ end  }}
         		</li>
         		{{ end }}

--- a/theme.toml
+++ b/theme.toml
@@ -6,7 +6,7 @@ license = "MIT"
 licenselink = "https://github.com/LordMathis/hugo-theme-nix/blob/master/LICENSE.md"
 description = "Simple theme for Hugo"
 homepage = "https://github.com/LordMathis/hugo-theme-nix/"
-tags = ["simple", "minimal", "unix", "terminal", "blog"]
+tags = ["simple", "minimal", "unix", "terminal", "blog", "multilingual"]
 features = ["blog"]
 min_version = 0.20
 


### PR DESCRIPTION
- Tag the theme as multilingual.
- Add alternate hreflang meta tags.
- Add lang switch where possible.
- Locale-independent date format.

This is how it looks like when a page is translated:

![Peek 01-03-2020 11-35](https://user-images.githubusercontent.com/973709/75624907-d8545a80-5bb0-11ea-9ae8-d95c4a5dab18.gif)
