### PR TITLE
Fix /posts typo and duplicated url

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,10 @@ To add a submenu item add `[[menu.header]]` item with a parent parameter to `con
     identifier = "post"
     name = "posts"
     weight = 0
-    url = "/post"
   [[menu.header]]
     parent = "post"
     name = "All Posts"
-    url = "/post"
+    url = "/posts"
   [[menu.header]]
     parent = "post"
     name = "categories"


### PR DESCRIPTION
The default Hugo dir (or at least the one in the [Quick Start official guide](https://gohugo.io/getting-started/quick-start/#step-4-add-some-content)) for posts should be "/posts" instead of "/post". This was getting me a 404 error while navigating to that page after following the QS Hugo guide and installing your theme.

Also, the url of the parent menu item was unnecessary (duplication of the "All Posts" first submenu item).