### PR TITLE
Hide empty box if no content in 'About' param

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -27,11 +27,13 @@
 					{{ partial "social.html" . }}
 					</div>
 				</div>
+				{{ with .Site.Params.About }}
 				<div class="row">
 					<div class="col-md-4 col-md-offset-4 user-description text-center">
-						<p>{{ .Site.Params.About }}</p>
+						<p>{{ . }}</p>
 					</div>
 				</div>
+				{{ end }}
 			</div>
 			{{ partial "footer.html" . }}
 		</div>


### PR DESCRIPTION
If no content is provided for the About param an empty box is displayed. This is a change to only display the row when the About param is not empty. 