### PR TITLE
Fix Youtube Link URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Optionaly you can add any of these social networks to the \[params\] section.
   TelegramID = "your_telegram"
   TwitterID = "your_twitter"
   XingURL = "https://www.xing.com/profile/..."
-  YoutubeID = "your_youtube_id"
+  # For youtube, since there are multiple path urls please add everything after https://youtube.com/ in channel url
+  YoutubeID = "c/your_youtube_id"
 ```
 
 To add a menu item add `[[menu.header]]` item to `config.toml`. For example:

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -41,7 +41,7 @@
 <a href="https://medium.com/@{{.}}" rel="me" title="Medium"><i class="fab fa-medium fa-3x" aria-hidden="true"></i></a>
 {{ end }}
 {{ with .Site.Params.YoutubeID }}
-<a href="https://youtube.com/c/{{.}}" rel="me" title="Youtube"><i class="fab fa-youtube fa-3x" aria-hidden="true"></i></a>
+<a href="https://youtube.com/channel/{{.}}" rel="me" title="Youtube"><i class="fab fa-youtube fa-3x" aria-hidden="true"></i></a>
 {{ end }}
 {{ with .Site.Params.SpotifyID }}
 <a href="https://open.spotify.com/user/{{.}}" rel="me" title="Spotify"><i class="fab fa-spotify fa-3x" aria-hidden="true"></i></a>

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -41,7 +41,8 @@
 <a href="https://medium.com/@{{.}}" rel="me" title="Medium"><i class="fab fa-medium fa-3x" aria-hidden="true"></i></a>
 {{ end }}
 {{ with .Site.Params.YoutubeID }}
-<a href="https://youtube.com/channel/{{.}}" rel="me" title="Youtube"><i class="fab fa-youtube fa-3x" aria-hidden="true"></i></a>
+<!-- For youtube, since there are multiple path urls please add everything after https://youtube.com/ in channel url -->
+<a href="https://youtube.com/{{.}}" rel="me" title="Youtube"><i class="fab fa-youtube fa-3x" aria-hidden="true"></i></a>
 {{ end }}
 {{ with .Site.Params.SpotifyID }}
 <a href="https://open.spotify.com/user/{{.}}" rel="me" title="Spotify"><i class="fab fa-spotify fa-3x" aria-hidden="true"></i></a>


### PR DESCRIPTION
I was using the theme and found out that my YouTube link was not working, the reason was that the theme had prefix `https://youtube.com/c/` which seems to be changed by YouTube, now it's `https://www.youtube.com/channel/`. I have tested it to be working on my setup.