### PR TITLE
Support nocomments=false

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -16,7 +16,7 @@
                 <div class="post-content">
                     {{ .Content }}
                 </div>
-                {{ if (isset .Params "nocomments")  }}
+                {{ if (.Params "nocomments")  }}
                 {{ else }}
                 <div class="post-comments">
                     {{ template "_internal/disqus.html" . }}


### PR DESCRIPTION
I use netlify cms to handle my hugo blog, and when you define a front matter param, it always needs to set it, be it true or false.

I think that the mere existence of the param is not the best way to test this. If you set `nocomments: false` in your front matter, IMHO it should display comments.