### PR TITLE
Updates GnuPG keyserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Optionaly you can add any of these social networks to the \[params\] section.
   FacebookID = "your_facebook"
   GithubID = "your_github"
   GitlabId = "your_gitlab"
+  # Uses keys.openpgp.org keyserver to search your fingerprint
+  # https://keys.openpgp.org/search?q=your_gpg_fingerprint
   GnuPGFingerprint = "your_gpg_fingerprint"
   GoogleAnalytics = "your_google_analytics_id"
   GoogleplusID = "your_googleplus"

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -1,5 +1,5 @@
 {{ with .Site.Params.GnuPGFingerprint }}
-<a href="https://pgp.key-server.io/pks/lookup?op=vindex&search=0x{{.}}" title="GPG"><i class="fas fa-unlock-alt fa-3x" aria-hidden="true"></i></a>
+<a href="https://keys.openpgp.org/search?q={{.}}" title="GPG"><i class="fas fa-unlock-alt fa-3x" aria-hidden="true"></i></a>
 {{ end }}
 {{ with .Site.Params.StackExchangeID }}
 <a href="https://stackexchange.com/users/{{.}}" rel="me" title="StackExchange"><i class="fab fa-stack-exchange fa-3x" aria-hidden="true"></i></a>


### PR DESCRIPTION
# Description

Changes the keyserver being used for the social link tied to the `GnuPGFingerprint` parameter from [https://pgp.key-server.io](https://pgp.key-server.io) to [https://keys.openpgp.org](https://keys.openpgp.org) due to the prior being no longer active.  In addition, this PR adds a descriptor for the `GnuPGFingerprint` under the [README](https://github.com/michael-valdron/hugo-theme-nix/blob/1b9a1d9964d3dfd76349076c82e03dea7f80663a/README.md) that makes mention of the keyserver.

# Issue

fixes #81 

