### PR TITLE
Add a "showdate" parameter that allows to publish pages without a date. default : true

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ To enable disqus comments add `disqusShortname` to your `config.toml`.
 
 You can turn off disqus comments per page by adding `nocomments = true` to the front matter.
 
+
+To disable the post date from a specific page add `showpostdate = false` to your relevant `.md` file.
+
 ## License
 
 Nix is licensed under the [MIT License](LICENSE.md)

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -12,7 +12,7 @@
     <div class="flex-wrapper">
         <div class="container wrapper">
             <h1><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
-            {{ if .Params.showthedate | default "true" }}
+            {{ if .Params.showpostdate | default "true" }}
             <span class="post-date">{{ .Date.Format "2006-01-02 " }}</span>
             {{ end }}
             <div class="post-content">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,27 +1,29 @@
 <!DOCTYPE html>
 <html>
 
-    <head>
-        <title> {{ .Title }} &middot; {{ .Site.Title }} </title>
+<head>
+    <title> {{ .Title }} &middot; {{ .Site.Title }} </title>
 
-        {{ partial "head.html" . }}
-    </head>
+    {{ partial "head.html" . }}
+</head>
 
-    <body>
-        {{ partial "header.html" . }}
-        <div class="flex-wrapper">
-            <div class="container wrapper">
-                <h1><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
-                <span class="post-date">{{ .Date.Format "2006-01-02 " }}</span>
-                <div class="post-content">
-                    {{ .Content }}
-                </div>
-                {{ if ne .Params.nocomments true }}
-                <div class="post-comments">
-                    {{ template "_internal/disqus.html" . }}
-                </div>
-                {{ end }}
+<body>
+    {{ partial "header.html" . }}
+    <div class="flex-wrapper">
+        <div class="container wrapper">
+            <h1><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
+            {{ if .Params.showthedate | default "true" }}
+            <span class="post-date">{{ .Date.Format "2006-01-02 " }}</span>
+            {{ end }}
+            <div class="post-content">
+                {{ .Content }}
             </div>
-            {{ partial "footer.html" . }}
+            {{ if ne .Params.nocomments true }}
+            <div class="post-comments">
+                {{ template "_internal/disqus.html" . }}
+            </div>
+            {{ end }}
         </div>
-    </body>
+        {{ partial "footer.html" . }}
+    </div>
+</body>


### PR DESCRIPTION
Add a "showdate" parameter that allows to publish pages without a date. default: true

Since the theme focuses on portfolio-type sites, it should be able to publish pages without a date.

the default choice is true, so all posts would still publish with a date and not break compatibility.