### PR TITLE
Add support for Lastmod on pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ To enable disqus comments add `disqusShortname` to your `config.toml`.
 
 You can turn off disqus comments per page by adding `nocomments = true` to the front matter.
 
-
 To disable the post date from a specific page add `showpostdate = false` to your relevant `.md` file.
+
+Pages now also support ![Lastmod](https://gohugo.io/methods/page/lastmod/). This will not appear until you populate `lastmod:` in the page's frontmatter, unless you have `enableGitInfo` set to `true` in your site's config file, in which case it will use the date of the last git commit containing that page.
 
 ## License
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,7 +3,6 @@
 
 <head>
     <title> {{ .Title }} &middot; {{ .Site.Title }} </title>
-
     {{ partial "head.html" . }}
 </head>
 
@@ -13,8 +12,13 @@
         <div class="container wrapper">
             <h1><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
             {{ if .Params.showpostdate | default "true" }}
-            <span class="post-date">{{ .Date.Format "2006-01-02 " }}</span>
+            {{ $postDate := .Date.Format "2006-01-02" }}
+            {{ $lastMod := .Lastmod.Format "2006-01-02" }}
+            <span class="post-date">{{ $postDate }}</span>
+            {{ if ne $lastMod $postDate }}
+            <br /> <span class="post-updated-date">(Last updated: {{ $lastMod }})</span>
             {{ end }}
+            {{ end }}            
             <div class="post-content">
                 {{ .Content }}
             </div>

--- a/static/css/nix.css
+++ b/static/css/nix.css
@@ -89,6 +89,11 @@ i {
 	float: right;
 }
 
+.post-updated-date {
+	float: right;
+    font-style: italic;
+}
+
 .post-header {
 	background-color: #F5F5F5;
 	overflow: hidden;


### PR DESCRIPTION
I'm not sure if this is something that wants to be included in the main repo, as it's starting to get away from Nix's "Simple" tag, but I wanted it for my website, so I decided to at least offer it here.

This update modifies the `single.html` template to add support for hugo's [Lastmod](https://gohugo.io/methods/page/lastmod/). It retains compatibility with #85, in that it will not try to display if `showpostdate` is set to `false`.

This *should* be a no-op for any existing site, as it will only do anything if `lastmod:` is set in the page's frontmatter, but there's an edge case if the site has `enableGitInfo` set to `true` in the site config, so I added a note to the readme.md to detail this.

If you want to see what this looks like in action, my fork is currently live on my personal website. There's only one page using it at the moment, and it's here: https://i.am.eddmil.es/posts/clevis-tang-truenas-scale/ 