### PR TITLE
Added Bluesky to social network list

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Optionaly you can add any of these social networks to the \[params\] section.
 
 ```
   BitbucketID = "your_bitbucket_id"
+  BlueskyID = "your_bluesky_id"
   CodepenID = "your_codepen"
   CvURL = "your_cv_url"
   Email = "your_email"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,7 +16,7 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>
 
 <!-- Font Awesome -->
-<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.7.1/css/all.css" integrity="sha384-QI8z31KmtR+tk1MYi0DfgxrjYgpTpLLol3bqZA/Q1Y8BvH+6k7/Huoj38gQOaCS7" crossorigin="anonymous">
 
 <!-- Custom CSS -->
 <link rel="stylesheet" href="{{ "css/nix.css" | absURL }}">

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -16,6 +16,9 @@
 {{ with .Site.Params.MastodonURL }}
 <a href="{{.}}" rel="me" title="Mastodon"><i class="fab fa-mastodon fa-3x" aria-hidden="true"></i></a>
 {{ end }}
+{{ with .Site.Params.BlueskyID }}
+<a href="https://bsky.app/profile/{{.}}" title="Bluesky"><i class="fab fa-bluesky fa-3x" aria-hidden="true"></i></a>
+{{ end }}
 {{ with .Site.Params.GoogleplusID }}
 <a href="https://plus.google.com/{{.}}/about" rel="me" title="Google+"><i class="fab fa-google-plus fa-3x" aria-hidden="true"></i></a>
 {{ end }}
@@ -83,4 +86,3 @@
 {{ with .Site.Params.RSSURL }}
 <a href="{{.}}" title="RSS"><i class="fa fa-rss fa-3x" aria-hidden="true"></i></a>
 {{ end }}
-


### PR DESCRIPTION
Hi, Me again :)

This is a quick PR to add support for Bluesky as a social network on the Nix home page (Mostly as I'm writing a blogpost to explain why I prefer mastodon to Bluesky :P). The only major change is that I've had to bump font awesome from 5.7.2 to 6.7.1 - the new version still contains all the symbols currently referenced, so I don't *think* this will cause any issues, but wanted to call it out.

Otherwise it's just an extra `with` statement in the social.html partial, and an extra line in the readme to cover the new option.

My fork is currently active on https://i.am.eddmil.es if you want to see how this looks deployed.