### PR TITLE
Support markdown parsing in about section

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -30,7 +30,7 @@
 				{{ with .Site.Params.About }}
 				<div class="row">
 					<div class="col-lg-4 offset-lg-4 user-description text-center">
-						<p>{{ . }}</p>
+						<p>{{ . | markdownify }}</p>
 					</div>
 				</div>
 				{{ end }}


### PR DESCRIPTION
The About parameter in `config.toml` doesn't render markdown links properly - they appear as plain text instead of clickable links. Also should support markdown formatting (bold/italic/...).

Before:

<img width="496" alt="image" src="https://github.com/user-attachments/assets/813d2bf1-9bb1-4a49-a403-6cc1aa1c7e5f" />

After:

<img width="494" alt="image" src="https://github.com/user-attachments/assets/9647ebd3-397d-4038-a5c2-e5c269179738" />

This change is not fully backward-compatible, however, I believe that pros outweigh cons.
