### PR TITLE
Fix bold text rendering in Chrome/Chromium browsers

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -27,7 +27,7 @@
 {{ end }}
 
 <!-- Google Fonts -->
-<link href="https://fonts.googleapis.com/css?family=Inconsolata%7COpen+Sans%7CConcert+One" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inconsolata&family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Concert+One&display=swap" rel="stylesheet">
 
 <!-- Google Analytics -->
 {{ with .Site.Params.GoogleAnalytics }}


### PR DESCRIPTION
Hey! I've noticed that while my previous PR (#88) fixed markdown processing, there was still an issue with bold font rendering. It turns out the bold version of the font wasn't properly loaded, so this should fix it. The solution: update to Google Fonts API v2 with explicit bold weights, which ensures consistent rendering across all browsers.


Again, before (from the previous PR): 
<img width="988" height="178" alt="image" src="https://github.com/user-attachments/assets/e7fa0ab3-afea-4368-8d18-90d1eb8c4e44" />

And after, where bold is actually bold: 

<img width="483" height="84" alt="image" src="https://github.com/user-attachments/assets/fdf0d62d-dc58-485d-bae5-feac09c71847" />

This also modernizes the font loading with better performance (display=swap).

I really like your theme and hope this helps other users too. Have a good day!